### PR TITLE
build_starlette_app 

### DIFF
--- a/pywebio/platform/__init__.py
+++ b/pywebio/platform/__init__.py
@@ -94,7 +94,7 @@ Also other dependency packages are required. You can install them with the follo
     pip3 install -U fastapi starlette uvicorn aiofiles websockets
 
 .. autofunction:: pywebio.platform.fastapi.webio_routes
-.. autofunction:: pywebio.platform.fastapi.build_starlette_app
+.. autofunction:: pywebio.platform.fastapi.asgi_app
 .. autofunction:: pywebio.platform.fastapi.start_server
 
 Other

--- a/pywebio/platform/__init__.py
+++ b/pywebio/platform/__init__.py
@@ -94,6 +94,7 @@ Also other dependency packages are required. You can install them with the follo
     pip3 install -U fastapi starlette uvicorn aiofiles websockets
 
 .. autofunction:: pywebio.platform.fastapi.webio_routes
+.. autofunction:: pywebio.platform.fastapi.build_starlette_app
 .. autofunction:: pywebio.platform.fastapi.start_server
 
 Other

--- a/pywebio/platform/fastapi.py
+++ b/pywebio/platform/fastapi.py
@@ -164,7 +164,12 @@ def start_server(applications, port=0, host='',
     uvicorn.run(app, host=host, port=port)
 
 
-def build_starlette_app(allowed_origins, applications, cdn, check_origin, debug, static_dir):
+def build_starlette_app(applications, static_dir=None, allowed_origins=None, cdn=True, check_origin=None, debug=False):
+    """"Build a starlette app providing PyWebIO application as a web service.
+    :param bool debug: Boolean indicating if debug tracebacks should be returned on errors.
+    The rest arguments of ``start_server()`` have the same meaning as for :func:`pywebio.platform.tornado.start_server`
+    .. versionadded:: 1.3
+    """
     kwargs = locals()
     try:
         from starlette.staticfiles import StaticFiles

--- a/pywebio/platform/fastapi.py
+++ b/pywebio/platform/fastapi.py
@@ -164,11 +164,26 @@ def start_server(applications, port=0, host='',
     uvicorn.run(app, host=host, port=port)
 
 
-def build_starlette_app(applications, static_dir=None, allowed_origins=None, cdn=True, check_origin=None, debug=False):
-    """"Build a starlette app providing PyWebIO application as a web service.
-    :param bool debug: Boolean indicating if debug tracebacks should be returned on errors.
-    The rest arguments of ``start_server()`` have the same meaning as for :func:`pywebio.platform.tornado.start_server`
-    .. versionadded:: 1.3
+def build_starlette_app(applications, cdn=True, static_dir=None, debug=False, allowed_origins=None, check_origin=None):
+    """Build a starlette app exposing a PyWebIO application including static files.
+
+Use :func:`pywebio.platform.fastapi.webio_routes` if you prefer handling static files yourself.
+same arguments for :func:`pywebio.platform.fastapi.webio_routes`
+
+:Example:
+
+To be used with ``mount`` to include pywebio as a subapp into an existing Starlette/FastAPI application
+
+>>> from fastapi import FastAPI
+>>> from pywebio.platform.fastapi import build_starlette_app
+>>> from pywebio.output import put_text
+>>> app = FastAPI()
+>>> subapp = build_starlette_app(lambda: put_text("hello from pywebio"))
+>>> app.mount("/pywebio", subapp)
+
+.. versionadded:: 1.3
+
+:Returns: Starlette app
     """
     kwargs = locals()
     try:


### PR DESCRIPTION
Hello,

`build_starlette_app` is extracted from `fastapi.start_server` in order to be used by FastAPI users who want to include a plug-and-play experience of `pywebio` into their existing FastAPI application.

It provides an intermediary level between `webio_routes` (that does not handle static files) and `start_server` (that launches a uvicorn server).

Indeed `start_server` is not usable for some users running FastAPI in production using both gunicorn and uvicorn (such as in https://github.com/tiangolo/uvicorn-gunicorn-fastapi-docker)