### PR TITLE
put_image example using bytes-like object

### DIFF
--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -215,8 +215,8 @@ Using output functions, you can output a variety of content, such as text, table
     ## ----
 
     # Image Output
-    img = open('/path/to/some/image.png', 'rb').read() 
-    put_image(img)  # ..doc-only
+    put_image(open('/path/to/some/image.png', 'rb').read())  # local image # ..doc-only
+    put_image('http://example.com/some-image.png')  # internet image # ..doc-only
     put_image('https://www.python.org/static/img/python-logo.png')  # ..demo-only
     ## ----
 

--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -215,7 +215,8 @@ Using output functions, you can output a variety of content, such as text, table
     ## ----
 
     # Image Output
-    put_image('some-image.png')  # ..doc-only
+    img = open('/path/to/some/image.png', 'rb').read() 
+    put_image(img)  # ..doc-only
     put_image('https://www.python.org/static/img/python-logo.png')  # ..demo-only
     ## ----
 


### PR DESCRIPTION
Google first leads us to the Guides page and I lost a couple of hours to figure out why my image wasn't being displayed, so I'm adding the opening from file example to the Guides page as well