### PR TITLE
Fixed chat_room's multiline input.

### DIFF
--- a/demos/chat_room.py
+++ b/demos/chat_room.py
@@ -65,8 +65,9 @@ async def main():
             break
         if data['cmd'] == t('Multiline Input', '多行输入'):
             data['msg'] = '\n' + await textarea('Message content', help_text=t('Message content supports Markdown syntax', '消息内容支持Markdown语法'))
-        put_markdown('`%s`: %s' % (nickname, data['msg']), sanitize=True, scope='msg-box')
-        chat_msgs.append((nickname, data['msg']))
+        if not(data['msg'] is None):
+            put_markdown('`%s`: %s' % (nickname, data['msg']), sanitize=True, scope='msg-box')
+            chat_msgs.append((nickname, data['msg']))
 
     refresh_task.close()
     toast("You have left the chat room")


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/36598604/207520670-1728028f-997f-41ea-ad88-0ee6f0dce2a2.png)
When multiline inputing, will echo blank.
Fixed it by condition statements.